### PR TITLE
Hide file upload feature temporarily (#10)

### DIFF
--- a/resources/views/team-leader/analysis/show.blade.php
+++ b/resources/views/team-leader/analysis/show.blade.php
@@ -361,7 +361,7 @@
                         @if ($stories->count() > 0)
                             <div class="divide-y divide-slate-200">
                                 @foreach ($stories as $story)
-                                    <div class="p-6" x-data="{ editing: false }">
+                                    <div class="p-6" x-data="{ editing: false, showDeleteModal: false }">
                                         <div class="flex items-start justify-between gap-4">
                                             <div class="flex-1">
                                                 <div class="flex items-center gap-2 mb-1">
@@ -452,18 +452,38 @@
                                                         </button>
                                                     </form>
                                                 @endif
-                                                <form action="{{ route('team-leader.analysis.delete-story', $story) }}" method="POST" onsubmit="return confirm('Delete this story?')" x-data="{ loading: false }" @submit="loading = true">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="inline-flex items-center rounded-lg border border-red-300 px-2 py-1.5 text-xs text-red-600 hover:bg-red-50" title="Delete" :disabled="loading">
-                                                        <template x-if="loading">
-                                                            <i class='fas fa-spinner fa-spin'></i>
-                                                        </template>
-                                                        <template x-if="!loading">
-                                                            <i class="fas fa-trash"></i>
-                                                        </template>
+                                                <button type="button" @click="showDeleteModal = true" class="inline-flex items-center rounded-lg border border-red-300 px-2 py-1.5 text-xs text-red-600 hover:bg-red-50" title="Delete">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                        {{-- Delete Confirmation Modal --}}
+                                        <div x-show="showDeleteModal" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="showDeleteModal = false">
+                                            <div class="relative w-full max-w-sm rounded-2xl bg-white shadow-xl ring-1 ring-slate-200">
+                                                {{-- Modal Header --}}
+                                                <div class="border-b border-slate-200 px-6 py-4">
+                                                    <h3 class="text-lg font-semibold text-slate-900">Delete Story</h3>
+                                                </div>
+
+                                                {{-- Modal Body --}}
+                                                <div class="px-6 py-4">
+                                                    <p class="text-sm text-slate-600">Are you sure you want to delete <strong>{{ $story->title }}</strong>? This action cannot be undone.</p>
+                                                </div>
+
+                                                {{-- Modal Footer --}}
+                                                <div class="border-t border-slate-200 flex gap-3 px-6 py-4">
+                                                    <button type="button" @click="showDeleteModal = false" class="flex-1 inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50">
+                                                        Cancel
                                                     </button>
-                                                </form>
+                                                    <form action="{{ route('team-leader.analysis.delete-story', $story) }}" method="POST" class="flex-1" @submit="showDeleteModal = false">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit" class="w-full inline-flex items-center justify-center rounded-lg border border-red-600 bg-red-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-700 hover:border-red-700">
+                                                            <i class="fas fa-trash mr-2"></i>Delete
+                                                        </button>
+                                                    </form>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/resources/views/team-leader/analysis/show.blade.php
+++ b/resources/views/team-leader/analysis/show.blade.php
@@ -284,7 +284,7 @@
 
                 {{-- User Stories --}}
                 @if ($team->userStories->count() > 0)
-                    <div class="bg-white overflow-hidden shadow-sm rounded-2xl ring-1 ring-slate-200">
+                    <div class="bg-white overflow-hidden shadow-sm rounded-2xl ring-1 ring-slate-200" x-data="{ deleteModalOpen: false, storyToDelete: null }" @keydown.escape="deleteModalOpen = false">
                         <div class="border-b border-slate-200 p-6">
                             <div class="flex items-center justify-between">
                                 <div>
@@ -359,7 +359,7 @@
 
                         {{-- User Stories List --}}
                         @if ($stories->count() > 0)
-                            <div class="divide-y divide-slate-200" x-data="{ deleteModalOpen: false, storyToDelete: null }" @keydown.escape="deleteModalOpen = false">
+                            <div class="divide-y divide-slate-200" x-data="{ editing: false }">
                                 @foreach ($stories as $story)
                                     <div class="p-6" x-data="{ editing: false }">
                                         <div class="flex items-start justify-between gap-4">
@@ -465,41 +465,41 @@
                             <div class="border-t border-slate-200 p-6">
                                 {{ $stories->links() }}
                             </div>
-
-                            {{-- Delete Confirmation Modal (Reusable) --}}
-                            <div x-show="deleteModalOpen" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="deleteModalOpen = false">
-                                <div class="relative w-full max-w-sm rounded-2xl bg-white shadow-xl ring-1 ring-slate-200">
-                                    {{-- Modal Header --}}
-                                    <div class="border-b border-slate-200 px-6 py-4">
-                                        <h3 class="text-lg font-semibold text-slate-900">Delete Story</h3>
-                                    </div>
-
-                                    {{-- Modal Body --}}
-                                    <div class="px-6 py-4">
-                                        <p class="text-sm text-slate-600">Are you sure you want to delete <strong x-text="storyToDelete?.title || ''"></strong>? This action cannot be undone.</p>
-                                    </div>
-
-                                    {{-- Modal Footer --}}
-                                    <div class="border-t border-slate-200 flex gap-3 px-6 py-4">
-                                        <button type="button" @click="deleteModalOpen = false" class="flex-1 inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50">
-                                            Cancel
-                                        </button>
-                                        <form :action="storyToDelete?.route" method="POST" class="flex-1" @submit="deleteModalOpen = false">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="submit" class="w-full inline-flex items-center justify-center rounded-lg border border-red-600 bg-red-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-700 hover:border-red-700">
-                                                <i class="fas fa-trash mr-2"></i>Delete
-                                            </button>
-                                        </form>
-                                    </div>
-                                </div>
-                            </div>
                         @else
                             <div class="p-6 text-center">
                                 <i class="fas fa-filter text-3xl text-slate-300 mb-3 block"></i>
                                 <p class="text-slate-600">No stories match your filters.</p>
                             </div>
                         @endif
+                    </div>
+
+                    {{-- Delete Confirmation Modal (Reusable) --}}
+                    <div x-show="deleteModalOpen" @click.self="deleteModalOpen = false" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+                        <div class="relative w-full max-w-sm rounded-2xl bg-white shadow-xl ring-1 ring-slate-200">
+                            {{-- Modal Header --}}
+                            <div class="border-b border-slate-200 px-6 py-4">
+                                <h3 class="text-lg font-semibold text-slate-900">Delete Story</h3>
+                            </div>
+
+                            {{-- Modal Body --}}
+                            <div class="px-6 py-4">
+                                <p class="text-sm text-slate-600">Are you sure you want to delete <strong x-text="storyToDelete?.title || ''"></strong>? This action cannot be undone.</p>
+                            </div>
+
+                            {{-- Modal Footer --}}
+                            <div class="border-t border-slate-200 flex gap-3 px-6 py-4">
+                                <button type="button" @click="deleteModalOpen = false" class="flex-1 inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50">
+                                    Cancel
+                                </button>
+                                <form id="deleteStoryForm" method="POST" class="flex-1" @submit.prevent="document.getElementById('deleteStoryForm').action = storyToDelete.route; document.getElementById('deleteStoryForm').submit()">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="w-full inline-flex items-center justify-center rounded-lg border border-red-600 bg-red-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-700 hover:border-red-700">
+                                        <i class="fas fa-trash mr-2"></i>Delete
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
                     </div>
 
                     {{-- Add Manual Story --}}

--- a/resources/views/team-leader/analysis/show.blade.php
+++ b/resources/views/team-leader/analysis/show.blade.php
@@ -359,9 +359,9 @@
 
                         {{-- User Stories List --}}
                         @if ($stories->count() > 0)
-                            <div class="divide-y divide-slate-200">
+                            <div class="divide-y divide-slate-200" x-data="{ deleteModalOpen: false, storyToDelete: null }" @keydown.escape="deleteModalOpen = false">
                                 @foreach ($stories as $story)
-                                    <div class="p-6" x-data="{ editing: false, showDeleteModal: false }">
+                                    <div class="p-6" x-data="{ editing: false }">
                                         <div class="flex items-start justify-between gap-4">
                                             <div class="flex-1">
                                                 <div class="flex items-center gap-2 mb-1">
@@ -452,38 +452,9 @@
                                                         </button>
                                                     </form>
                                                 @endif
-                                                <button type="button" @click="showDeleteModal = true" class="inline-flex items-center rounded-lg border border-red-300 px-2 py-1.5 text-xs text-red-600 hover:bg-red-50" title="Delete">
+                                                <button type="button" @click="deleteModalOpen = true; storyToDelete = { id: {{ $story->id }}, title: '{{ addslashes($story->title) }}', route: '{{ route('team-leader.analysis.delete-story', $story) }}' }" class="inline-flex items-center rounded-lg border border-red-300 px-2 py-1.5 text-xs text-red-600 hover:bg-red-50" title="Delete">
                                                     <i class="fas fa-trash"></i>
                                                 </button>
-                                            </div>
-                                        </div>
-
-                                        {{-- Delete Confirmation Modal --}}
-                                        <div x-show="showDeleteModal" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="showDeleteModal = false">
-                                            <div class="relative w-full max-w-sm rounded-2xl bg-white shadow-xl ring-1 ring-slate-200">
-                                                {{-- Modal Header --}}
-                                                <div class="border-b border-slate-200 px-6 py-4">
-                                                    <h3 class="text-lg font-semibold text-slate-900">Delete Story</h3>
-                                                </div>
-
-                                                {{-- Modal Body --}}
-                                                <div class="px-6 py-4">
-                                                    <p class="text-sm text-slate-600">Are you sure you want to delete <strong>{{ $story->title }}</strong>? This action cannot be undone.</p>
-                                                </div>
-
-                                                {{-- Modal Footer --}}
-                                                <div class="border-t border-slate-200 flex gap-3 px-6 py-4">
-                                                    <button type="button" @click="showDeleteModal = false" class="flex-1 inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50">
-                                                        Cancel
-                                                    </button>
-                                                    <form action="{{ route('team-leader.analysis.delete-story', $story) }}" method="POST" class="flex-1" @submit="showDeleteModal = false">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="w-full inline-flex items-center justify-center rounded-lg border border-red-600 bg-red-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-700 hover:border-red-700">
-                                                            <i class="fas fa-trash mr-2"></i>Delete
-                                                        </button>
-                                                    </form>
-                                                </div>
                                             </div>
                                         </div>
                                     </div>
@@ -493,6 +464,35 @@
                             {{-- Pagination --}}
                             <div class="border-t border-slate-200 p-6">
                                 {{ $stories->links() }}
+                            </div>
+
+                            {{-- Delete Confirmation Modal (Reusable) --}}
+                            <div x-show="deleteModalOpen" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="deleteModalOpen = false">
+                                <div class="relative w-full max-w-sm rounded-2xl bg-white shadow-xl ring-1 ring-slate-200">
+                                    {{-- Modal Header --}}
+                                    <div class="border-b border-slate-200 px-6 py-4">
+                                        <h3 class="text-lg font-semibold text-slate-900">Delete Story</h3>
+                                    </div>
+
+                                    {{-- Modal Body --}}
+                                    <div class="px-6 py-4">
+                                        <p class="text-sm text-slate-600">Are you sure you want to delete <strong x-text="storyToDelete?.title || ''"></strong>? This action cannot be undone.</p>
+                                    </div>
+
+                                    {{-- Modal Footer --}}
+                                    <div class="border-t border-slate-200 flex gap-3 px-6 py-4">
+                                        <button type="button" @click="deleteModalOpen = false" class="flex-1 inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-700 hover:bg-slate-50">
+                                            Cancel
+                                        </button>
+                                        <form :action="storyToDelete?.route" method="POST" class="flex-1" @submit="deleteModalOpen = false">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="w-full inline-flex items-center justify-center rounded-lg border border-red-600 bg-red-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-red-700 hover:border-red-700">
+                                                <i class="fas fa-trash mr-2"></i>Delete
+                                            </button>
+                                        </form>
+                                    </div>
+                                </div>
                             </div>
                         @else
                             <div class="p-6 text-center">


### PR DESCRIPTION
## What
Hide the file upload (Project Documents) section for the instructor presentation.

## Why
Making the system feel more streamlined for demo purposes. Instructors can be given the ability to upload documents later, making them feel more in control.

## Changes
- Hide Project Documents section using @if(false) (easy to restore)
- Update page header to remove 'Upload documents'
- Keeps Project Description (plaintext) section visible

## To Re-enable
Change `@if(false)` to `@if(true)` on line 96 of show.blade.php

Closes #10